### PR TITLE
Fix empty Outline View for .gui resources that reference an invalid or unmigrated spine scene

### DIFF
--- a/defold-spine/editor/src/spineext.clj
+++ b/defold-spine/editor/src/spineext.clj
@@ -268,7 +268,7 @@
   (not= 0 (bit-and mask (bit-shift-left 1 count))))
 
 ; See GetOpenGLCompareFunc in graphics_opengl.cpp
-(defn- stencil-func->gl-func [func]
+(defn- stencil-func->gl-func [^long func]
   (case func
     0 GL/GL_NEVER
     1 GL/GL_LESS
@@ -279,7 +279,7 @@
     6 GL/GL_NOTEQUAL
     7 GL/GL_ALWAYS))
 
-(defn- stencil-op->gl-op [op]
+(defn- stencil-op->gl-op [^long op]
   (case op
     0 GL/GL_KEEP
     1 GL/GL_ZERO
@@ -537,8 +537,8 @@
   (with-open [in (io/input-stream resource)]
     (IOUtils/toByteArray in)))
 
-(defn- handle-read-error [error node-id resource]
-  (let [error (if (instance? java.lang.reflect.InvocationTargetException error) (.getCause error) error)
+(defn- handle-read-error [^Throwable error node-id resource]
+  (let [^Throwable error (if (instance? java.lang.reflect.InvocationTargetException error) (.getCause error) error)
         msg (.getMessage error)
         path (resource/resource->proj-path resource)
         msg-missing-image "Region not found"]

--- a/defold-spine/editor/src/spineguiext.clj
+++ b/defold-spine/editor/src/spineguiext.clj
@@ -146,7 +146,7 @@
   ;; The handle to the C++ resource
   (output spine-data-handle g/Any (g/fnk [spine-scene-infos spine-scene]
                                          (:spine-data-handle (or (spine-scene-infos spine-scene)
-                                                              (spine-scene-infos "")))))
+                                                                 (spine-scene-infos "")))))
   
   (output spine-vertex-buffer g/Any :cached (g/fnk [spine-scene spine-data-handle spine-skin spine-default-animation]
                                                    (produce-local-vertices spine-data-handle spine-skin spine-default-animation 0.0)))
@@ -254,7 +254,7 @@
   (input name-counts gui/NameCounts)
   (input spine-scene-resource resource/Resource)
   
-  (input spine-data-handle g/Any) ; The c++ pointer
+  (input spine-data-handle g/Any :substitute nil) ; The c++ pointer
   (output spine-data-handle g/Any (gu/passthrough spine-data-handle))
 
   (input spine-anim-ids g/Any :substitute (constantly nil))


### PR DESCRIPTION
### User-facing changes
* The Outline View will no longer be empty if you open a `.gui` resource that reference an invalid or unmigrated Spine scene in the editor.

### Technical changes
* The `spine-data-handle` output on `SpineSceneNode` will now produce `nil` instead of an `ErrorValue` in case the referenced `.spinescene` contains errors. It looks very much like this was the intention from the comments on lines `206` and `216` of `spineguiext.clj`
* Fixed some performance warnings that were showing up in the editor when you load `extension-spine`.