### PR TITLE
Mark spinejson resource type as textual

### DIFF
--- a/defold-spine/editor/src/spineext.clj
+++ b/defold-spine/editor/src/spineext.clj
@@ -1008,6 +1008,7 @@
    (workspace/register-resource-type workspace
                                      :ext spine-json-ext
                                      :node-type SpineSceneJson
+                                     :textual? true
                                      :load-fn load-spine-json
                                      :icon spine-json-icon
                                      :view-types [:default]


### PR DESCRIPTION
This change will enable Search in Files in spinejson files after https://github.com/defold/defold/pull/7642 is merged.

Related to https://github.com/defold/defold/issues/7586