### PR TITLE
Allow copy-paste of Spine Scenes in Gui

### DIFF
--- a/defold-spine/editor/src/spineguiext.clj
+++ b/defold-spine/editor/src/spineguiext.clj
@@ -334,7 +334,11 @@
   (output name-counts gui/NameCounts :cached (g/fnk [names] (frequencies names)))
   (input build-errors g/Any :array)
   (output build-errors g/Any (gu/passthrough build-errors))
-  (output node-outline outline/OutlineData :cached (gui/gen-outline-fnk "Spine Scenes" "Spine Scenes" 6 false []))
+  (output node-outline outline/OutlineData :cached
+          (gui/gen-outline-fnk
+            "Spine Scenes" "Spine Scenes" 6 false
+            [{:node-type SpineSceneNode
+              :tx-attach-fn (gui/gen-outline-node-tx-attach-fn attach-spine-scene)}]))
   (output add-handler-info g/Any
           (g/fnk [_node-id]
                  [_node-id "Spine Scenes..." spineext/spine-scene-icon add-spine-scenes-handler {}])))

--- a/defold-spine/pluginsrc/com/defold/bob/pipeline/Spine.java
+++ b/defold-spine/pluginsrc/com/defold/bob/pipeline/Spine.java
@@ -300,7 +300,7 @@ public class Spine {
     {
         if (first == null)
         {
-            System.out.printf("String buffer is empty!");
+            // System.out.printf("String buffer is empty!\n");
             return new String[0];
         }
         int count = pcount.getValue();


### PR DESCRIPTION
You can now copy and paste Spine Scene resources when editing Gui scenes.