### PR TITLE
Added Lua annotations

### DIFF
--- a/defold-spine/api/spine.lua
+++ b/defold-spine/api/spine.lua
@@ -1,0 +1,142 @@
+--[[
+Spine API documentation
+Functions and constants for interacting with Spine models
+--]]
+
+---@meta
+---@diagnostic disable: lowercase-global
+---@diagnostic disable: missing-return
+---@diagnostic disable: duplicate-doc-param
+---@diagnostic disable: duplicate-set-field
+---@diagnostic disable: args-after-dots
+
+---@class defold_api.spine
+spine = {}
+
+---@class spine.play_anim.options
+---@field blend_duration? number Duration of a linear blend between the current and new animation.
+---@field offset? number The normalized initial value of the animation cursor when the animation starts playing.
+---@field playback_rate? number The rate with which the animation will be played. Must be positive.
+---@field track? number The track index of the animation. Defaults to 1. Animations on different tracks play in parallel.
+
+---@class spine.play_anim.callback_function.message
+---@field animation_id hash The animation that was completed
+---@field track number The track index of the animation
+---@field playback? constant (spine_animation_done only!) The playback mode for the animation
+---@field event_id? hash (spine_event only!) the event that was triggered.
+---@field t? number (spine_event only!) the time at which the event occurred (seconds)
+---@field integer? number (spine_event only!) a custom integer associated with the event (0 by default).
+---@field float? number (spine_event only!) a custom float associated with the event (0 by default)
+---@field string? hash (spine_event only!) a custom string associated with the event (hash("") by default)
+
+---Plays the specified animation on a Spine model.
+---A `spine_animation_done` message is sent to the callback (or message handler).
+---Any spine events will also be handled in the same way.
+---The callback is not called (or message sent) if the animation is cancelled with spine.cancel.
+---The callback is called (or message sent) only for animations that play with the following playback modes:
+---* go.PLAYBACK_ONCE_FORWARD
+---* go.PLAYBACK_ONCE_BACKWARD
+---* go.PLAYBACK_ONCE_PINGPONG
+---@param url string|hash|url The Spine model for which to play an animation
+---@param anim_id hash Id of the animation to play
+---@param playback number Playback mode of the animation (from go.PLAYBACK_*)
+---@param options spine.play_anim.options Playback options
+---@param callback_function? fun(self: userdata, message_id: hash, message: spine.play_anim.callback_function.message, sender: url) function to call when the animation has completed or a Spine event occured
+function spine.play_anim(url, anim_id, playback, options, callback_function) end
+
+---@class spine.cancel.options
+---@field track? number The index of the track which to cancel the animation on. Defaults to all animations on all tracks
+
+---Cancels all running animations on a specified spine model component
+---@param url string|hash|url The Spine model for which to cancel the animation
+---@param options? spine.cancel.options Cancel options
+function spine.cancel(url, options) end
+
+---Returns the id of the game object that corresponds to a specified skeleton bone.
+---@param url string|hash|url The Spine model to query
+---@param bone_id hash Id of the corresponding bone
+---@return hash id Id of the game object
+function spine.get_go(url, bone_id) end
+
+---Sets the spine skin on a spine model.
+---@param url string|hash|url The Spine model to query
+---@param skin string|hash Id of the corresponding skin
+function spine.set_skin(url, skin) end
+
+---Adds one spine skin on a spine model to another on the same model.
+---@param url string|hash|url The Spine model to query
+---@param skin_a string|hash Id of the corresponding skin that will recieve the added skin
+---@param skin_b string|hash Id of the corresponding skin to add
+function spine.add_skin(url, skin_a, skin_b) end
+
+---Copies one spine skin on a spine model to another on the same model.
+---@param url string|hash|url The Spine model to query
+---@param skin_a string|hash Id of the corresponding skin that will recieve the copied skin
+---@param skin_b string|hash Id of the corresponding skin to copy
+function spine.copy_skin(url, skin_a, skin_b) end
+
+---Clear all attachments and constraints from a skin on a spine model
+---@param url string|hash|url The Spine model to query
+---@param skin string|hash Id of the corresponding skin
+function spine.clear_skin(url, skin) end
+
+---Set the attachment of a slot on a spine model.
+---@param url string|hash|url The Spine model to query
+---@param slot string|hash Id of the slot
+---@param attachment? string|hash Id of the attachment. May be nil to reset to default attachment.
+function spine.set_attachment(url, slot, attachment) end
+
+---Set the color a slot will tint its attachments on a spine model.
+---@param url string|hash|url The Spine model to query
+---@param slot string|hash Id of the slot
+---@param color vector4 Tint applied to attachments in a slot
+function spine.set_slot_color(url, slot, color) end
+
+---Resets a shader constant for a spine model component. (Previously set with go.set())
+---@param url string|hash|url The Spine model to query
+---@param constant string|hash name of the constant
+function spine.reset_constant(url, constant) end
+
+---Reset the IK constraint target position to default of a spinemodel.
+---@param url string|hash|url The Spine model
+---@param ik_constraint_id string|hash id of the corresponding IK constraint
+function spine.reset_ik_target(url, ik_constraint_id) end
+
+---Set the target position of an IK constraint object.
+---@param url string|hash|url The Spine model
+---@param ik_constraint_id string|hash id of the corresponding IK constraint
+---@param position vector3 target position
+function spine.set_ik_target_position(url, ik_constraint_id, position) end
+
+---Set the IK constraint object target position to follow position.
+---@param url string|hash|url The Spine model to query
+---@param ik_constraint_id string|hash id of the corresponding IK constraint
+---@param target_url string|hash|url target game object
+function spine.set_ik_target(url, ik_constraint_id, target_url) end
+
+---Apply a physics-based translation to the Spine model.
+---@param url string|hash|url The Spine model component to translate
+---@param translation vector3 The translation vector to apply to the Spine model
+function spine.physics_translate(url, translation) end
+
+---Apply a physics-based rotation to the Spine model.
+---@param url string|hash|url The Spine model component to rotate
+---@param center vector3 The center point around which to rotate
+---@param degrees number The rotation angle in degrees
+function spine.physics_rotate(url, center, degrees) end
+
+---The animation has been finished. Only received if there is no callback set!
+---@class on_message.spine_animation_done
+---@field animation_id hash The animation that was completed
+---@field playback constant The playback mode for the animation
+---@field track number The track index of the animation
+
+---A spine event sent by the currently playing animation. Only received if there is no callback set!
+---@class on_message.spine_event
+---@field event_id hash The event name
+---@field animation_id hash The animation that sent the event
+---@field blend_weight number The current blend weight
+---@field t number The current animation time
+---@field integer? number The event value. nil if not present
+---@field float? number The event value. nil if not present
+---@field string? string The event value. nil if not present

--- a/defold-spine/api/spine_gui.lua
+++ b/defold-spine/api/spine_gui.lua
@@ -1,0 +1,158 @@
+--[[
+Spine GUI API documentation
+Functions and constants for interacting with Spine models in GUI
+--]]
+
+---@meta
+---@diagnostic disable: lowercase-global
+---@diagnostic disable: missing-return
+---@diagnostic disable: duplicate-doc-param
+---@diagnostic disable: duplicate-set-field
+---@diagnostic disable: args-after-dots
+
+---Dynamically create a new spine node.
+---@param pos vector3|vector4 node position
+---@param spine_scene string|hash spine scene id
+---@return node node new spine node
+function gui.new_spine_node(pos, spine_scene) end
+
+---@class gui.play_spine_anim.play_properties
+---@field blend_duration? number The duration of a linear blend between the current and new animation
+---@field offset? number The normalized initial value of the animation cursor when the animation starts playing
+---@field playback_rate? number The rate with which the animation will be played. Must be positive
+
+---Starts a spine animation.
+---@param node node spine node that should play the animation
+---@param animation_id string|hash id of the animation to play
+---@param playback constant playback mode
+--- - `gui.PLAYBACK_ONCE_FORWARD`
+--- - `gui.PLAYBACK_ONCE_BACKWARD`
+--- - `gui.PLAYBACK_ONCE_PINGPONG`
+--- - `gui.PLAYBACK_LOOP_FORWARD`
+--- - `gui.PLAYBACK_LOOP_BACKWARD`
+--- - `gui.PLAYBACK_LOOP_PINGPONG`
+---@param play_properties? gui.play_spine_anim.play_properties optional table with properties
+---@param complete_function? fun(self: userdata, node: node) function to call when the animation has completed
+function gui.play_spine_anim(node, animation_id, playback, play_properties, complete_function) end
+
+---cancel a spine animation
+---@param node node spine node that should cancel its animation
+function gui.cancel_spine(node) end
+
+---The returned node can be used for parenting and transform queries.
+---This function has complexity O(n), where n is the number of bones in the spine model skeleton.
+---@param node node spine node to query for bone node
+---@param bone_id string|hash id of the corresponding bone
+---@return node bone node corresponding to the spine bone
+function gui.get_spine_bone(node, bone_id) end
+
+---Set the spine scene on a spine node. The spine scene must be mapped to the gui scene in the gui editor.
+---@param node node node to set spine scene for
+---@param spine_scene string|hash spine scene id
+function gui.set_spine_scene(node, spine_scene) end
+
+---Returns the spine scene id of the supplied node.
+---This is currently only useful for spine nodes.
+---The returned spine scene must be mapped to the gui scene in the gui editor.
+---@param node node node to get texture from
+---@return hash spine_scene spine scene id
+function gui.get_spine_scene(node) end
+
+---Sets the spine skin on a spine node.
+---@param node node node to set the spine skin on
+---@param spine_skin string|hash spine skin id
+---@example
+---```
+---function init(self)
+---  gui.set_spine_skin(gui.get_node("spine_node"), "monster")
+---end
+---```
+function gui.set_spine_skin(node, spine_skin) end
+
+---Add a spine skin on a spine node to another skin on the same node.
+---@param node node node having both skins
+---@param spine_skin_a string|hash spine skin id that recieves other skin
+---@param spine_skin_b string|hash spine skin id that will be added
+---@example
+---```
+---function init(self)
+---  gui.add_spine_skin(gui.get_node("spine_node"), "monster_head", "monster_body")
+---end
+---```
+function gui.add_spine_skin(node, spine_skin_a, spine_skin_b) end
+
+---Copy a spine skin on a spine node to another skin on the same node.
+---@param node node node having both skins
+---@param spine_skin_a string|hash spine skin id that copies other skin
+---@param spine_skin_b string|hash spine skin id that will be copied
+---@example
+---```
+---function init(self)
+---  gui.copy_spine_skin(gui.get_node("spine_node"), "monster_head", "monster_body")
+---end
+---```
+function gui.copy_spine_skin(node, spine_skin_a, spine_skin_b) end
+
+---Clear a spine skin on a spine node of all attachments and constraints
+---@param node node node having both skins
+---@param spine_skin string|hash spine skin id
+---@example
+---```
+---function init(self)
+---  gui.clear_spine_skin(gui.get_node("spine_node"), "monster")
+---end
+---```
+function gui.clear_spine_skin(node, spine_skin) end
+
+---Gets the spine skin of a spine node
+---@param node node node to get spine skin from
+---@return hash id spine skin id, 0 if no explicit skin is set
+function gui.get_spine_skin(node) end
+
+---Gets the playing animation on a spine node
+---@param node node node to get spine skin from
+---@return hash id spine animation id, 0 if no animation is playing
+function gui.get_spine_animation(node) end
+
+---This is only useful for spine nodes. The cursor is normalized.
+---@param node node spine node to set the cursor for
+---@param cursor number cursor value
+function gui.set_spine_cursor(node, cursor) end
+
+---This is only useful for spine nodes. Gets the normalized cursor of the animation on a spine node.
+---@param node node spine node to get the cursor for (node)
+---@return number cursor_value cursor value
+function gui.get_spine_cursor(node) end
+
+---This is only useful for spine nodes. Sets the playback rate of the animation on a spine node. Must be positive.
+---@param node node spine node to set the cursor for
+---@param playback_rate number playback rate
+function gui.set_spine_playback_rate(node, playback_rate) end
+
+---This is only useful for spine nodes. Gets the playback rate of the animation on a spine node.
+---@param node node spine node to set the cursor for
+---@return number rate playback rate
+function gui.get_spine_playback_rate(node) end
+
+---This is only useful for spine nodes. Sets an attachment to a slot on a spine node.
+---@param node node spine node to set the slot for
+---@param slot string|hash slot name
+---@param attachment? string|hash attachment name. May be nil.
+function gui.set_spine_attachment(node, slot, attachment) end
+
+---This is only useful for spine nodes. Sets a tint for all attachments on a slot
+---@param node node spine node to set the slot for
+---@param slot string|hash slot name
+---@param color vector4 target color.
+function gui.set_spine_slot_color(node, slot, color) end
+
+---Apply a physics-based translation to the Spine GUI node.
+---@param node node The Spine GUI node to translate.
+---@param translation vector3 The translation vector to apply to the Spine GUI node.
+function gui.spine_physics_translate(node, translation) end
+
+---Apply a physics-based rotation to the Spine GUI node.
+---@param node node The Spine GUI node to rotate.
+---@param center vector3 The center point around which to rotate.
+---@param degrees number The rotation angle in degrees.
+function gui.spine_physics_rotate(node, center, degrees) end


### PR DESCRIPTION
These annotations can be used in any text editor with Lua Language Server.
They are generated from `*.script_api` files using AI, and then reviewed manually.

It uses the existing types `url`, `hash`, `node`, `vector3`, `vector4` and the namespace `gui`, which are already defined in the [defold-annotations](https://github.com/astrochili/defold-annotations) releases.

Note: I'm not sure about optionality of all these params and return values because I guess the original doc doesn't cover optional params perfectly. But that's another question.