### PR TITLE
Added tracks for Spine Nodes in GUI

### DIFF
--- a/defold-spine/api/spine_gui.lua
+++ b/defold-spine/api/spine_gui.lua
@@ -20,6 +20,7 @@ function gui.new_spine_node(pos, spine_scene) end
 ---@field blend_duration? number The duration of a linear blend between the current and new animation
 ---@field offset? number The normalized initial value of the animation cursor when the animation starts playing
 ---@field playback_rate? number The rate with which the animation will be played. Must be positive
+---@field track? number The track to play the animation on (1-based indexing, defaults to 1)
 
 ---Starts a spine animation.
 ---@param node node spine node that should play the animation
@@ -32,12 +33,16 @@ function gui.new_spine_node(pos, spine_scene) end
 --- - `gui.PLAYBACK_LOOP_BACKWARD`
 --- - `gui.PLAYBACK_LOOP_PINGPONG`
 ---@param play_properties? gui.play_spine_anim.play_properties optional table with properties
----@param complete_function? fun(self: userdata, node: node) function to call when the animation has completed
+---@param complete_function? fun(self: userdata, node: node, message_id: hash, message: table) function to call when the animation has completed or when spine events occur
 function gui.play_spine_anim(node, animation_id, playback, play_properties, complete_function) end
 
----cancel a spine animation
+---@class gui.cancel_spine.cancel_properties
+---@field track? number The track to cancel (-1 for all tracks, defaults to all tracks)
+
+---Cancel a spine animation
 ---@param node node spine node that should cancel its animation
-function gui.cancel_spine(node) end
+---@param cancel_properties? gui.cancel_spine.cancel_properties optional table with properties
+function gui.cancel_spine(node, cancel_properties) end
 
 ---The returned node can be used for parenting and transform queries.
 ---This function has complexity O(n), where n is the number of bones in the spine model skeleton.
@@ -109,30 +114,50 @@ function gui.clear_spine_skin(node, spine_skin) end
 ---@return hash id spine skin id, 0 if no explicit skin is set
 function gui.get_spine_skin(node) end
 
+---@class gui.get_spine_animation.get_properties
+---@field track? number The track to get animation from (defaults to 1)
+
 ---Gets the playing animation on a spine node
----@param node node node to get spine skin from
+---@param node node node to get spine animation from
+---@param get_properties? gui.get_spine_animation.get_properties optional table with properties
 ---@return hash id spine animation id, 0 if no animation is playing
-function gui.get_spine_animation(node) end
+function gui.get_spine_animation(node, get_properties) end
+
+---@class gui.set_spine_cursor.cursor_properties
+---@field track? number The track to set cursor for (defaults to 1)
 
 ---This is only useful for spine nodes. The cursor is normalized.
 ---@param node node spine node to set the cursor for
 ---@param cursor number cursor value
-function gui.set_spine_cursor(node, cursor) end
+---@param cursor_properties? gui.set_spine_cursor.cursor_properties optional table with properties
+function gui.set_spine_cursor(node, cursor, cursor_properties) end
+
+---@class gui.get_spine_cursor.cursor_properties
+---@field track? number The track to get cursor from (defaults to 1)
 
 ---This is only useful for spine nodes. Gets the normalized cursor of the animation on a spine node.
 ---@param node node spine node to get the cursor for (node)
+---@param cursor_properties? gui.get_spine_cursor.cursor_properties optional table with properties
 ---@return number cursor_value cursor value
-function gui.get_spine_cursor(node) end
+function gui.get_spine_cursor(node, cursor_properties) end
+
+---@class gui.set_spine_playback_rate.rate_properties
+---@field track? number The track to set playback rate for (defaults to 1)
 
 ---This is only useful for spine nodes. Sets the playback rate of the animation on a spine node. Must be positive.
 ---@param node node spine node to set the cursor for
 ---@param playback_rate number playback rate
-function gui.set_spine_playback_rate(node, playback_rate) end
+---@param rate_properties? gui.set_spine_playback_rate.rate_properties optional table with properties
+function gui.set_spine_playback_rate(node, playback_rate, rate_properties) end
+
+---@class gui.get_spine_playback_rate.rate_properties
+---@field track? number The track to get playback rate from (defaults to 1)
 
 ---This is only useful for spine nodes. Gets the playback rate of the animation on a spine node.
 ---@param node node spine node to set the cursor for
+---@param rate_properties? gui.get_spine_playback_rate.rate_properties optional table with properties
 ---@return number rate playback rate
-function gui.get_spine_playback_rate(node) end
+function gui.get_spine_playback_rate(node, rate_properties) end
 
 ---This is only useful for spine nodes. Sets an attachment to a slot on a spine node.
 ---@param node node spine node to set the slot for

--- a/defold-spine/api/spine_gui.script_api
+++ b/defold-spine/api/spine_gui.script_api
@@ -53,10 +53,14 @@
                 - name: playback_rate
                   type: number
                   desc: The rate with which the animation will be played. Must be positive
-               
+
+                - name: track
+                  type: number
+                  desc: The track number for the animation (1-based). Defaults to track 1. Multiple tracks allow for layered animations.
+
         - name: complete_function
-          type: function(self, node)
-          desc: function to call when the animation has completed
+          type: function(self, node, message_id, message)
+          desc: function to call when the animation has completed or when spine events occur
 
 
     - name: cancel_spine
@@ -66,6 +70,13 @@
         - name: node
           type: node
           desc: spine node that should cancel its animation
+        - name: options
+          type: table
+          desc: optional table with properties
+          parameters:
+                - name: track
+                  type: number
+                  desc: The track number to cancel (1-based). If not specified, cancels all tracks.
 
 
     - name: get_spine_bone
@@ -221,7 +232,14 @@
       parameters:
         - name: node
           type: node
-          desc: node to get spine skin from
+          desc: node to get spine animation from
+        - name: options
+          type: table
+          desc: optional table with properties
+          parameters:
+                - name: track
+                  type: number
+                  desc: The track number to get animation from (1-based). Defaults to track 1.
       return:
         - name: id
           type: hash
@@ -238,6 +256,13 @@
         - name: cursor
           type: number
           desc: cursor value
+        - name: options
+          type: table
+          desc: optional table with properties
+          parameters:
+                - name: track
+                  type: number
+                  desc: The track number to set cursor for (1-based). Defaults to track 1.
 
 
     - name: get_spine_cursor
@@ -246,7 +271,14 @@
       parameters:
         - name: node
           type: node
-          desc: spine node to get the cursor for (node)
+          desc: spine node to get the cursor for
+        - name: options
+          type: table
+          desc: optional table with properties
+          parameters:
+                - name: track
+                  type: number
+                  desc: The track number to get cursor from (1-based). Defaults to track 1.
       return:
         - name: cursor_value
           type: number
@@ -259,10 +291,17 @@
       parameters:
         - name: node
           type: node
-          desc: spine node to set the cursor for
+          desc: spine node to set the playback rate for
         - name: playback_rate
           type: number
           desc: playback rate
+        - name: options
+          type: table
+          desc: optional table with properties
+          parameters:
+                - name: track
+                  type: number
+                  desc: The track number to set playback rate for (1-based). Defaults to track 1.
 
 
     - name: get_spine_playback_rate
@@ -271,7 +310,14 @@
       parameters:
         - name: node
           type: node
-          desc: spine node to set the cursor for
+          desc: spine node to get the playback rate for
+        - name: options
+          type: table
+          desc: optional table with properties
+          parameters:
+                - name: track
+                  type: number
+                  desc: The track number to get playback rate from (1-based). Defaults to track 1.
       return:
         - name: rate
           type: number

--- a/defold-spine/src/gui_node_spine.cpp
+++ b/defold-spine/src/gui_node_spine.cpp
@@ -49,13 +49,12 @@ struct InternalGuiNode
 
     spSkeleton*         m_SkeletonInstance;
     spAnimationState*   m_AnimationStateInstance;
-    spTrackEntry*       m_AnimationInstance;
-    dmhash_t            m_AnimationId;
+    dmArray<dmSpine::GuiSpineAnimationTrack> m_AnimationTracks;
+    
     dmhash_t            m_SkinId;
 
     dmVMath::Matrix4    m_Transform; // the world transform
 
-    dmGui::Playback     m_Playback;
     dmGui::HScene       m_GuiScene;
     dmGui::HNode        m_GuiNode;
     dmGui::AdjustMode   m_AdjustMode;
@@ -70,31 +69,19 @@ struct InternalGuiNode
     dmArray<GuiIKTarget>    m_IKTargets;           // targets that follow GUI nodes
     dmArray<GuiIKTarget>    m_IKTargetPositions;   // targets with fixed positions
 
-    dmScript::LuaCallbackInfo* m_Callback;
-    dmScript::LuaCallbackInfo* m_NextCallback; // If the current callback calls play_anim with another callback
-
-    uint8_t             m_Playing : 1;
-    uint8_t             m_UseCursor : 1;
     uint8_t             m_FindBones : 1;
-    uint8_t             m_HasNextCallback : 1;
     uint8_t             m_FirstUpdate : 1;
-    uint8_t             : 3;
+    uint8_t             : 6;
 
     InternalGuiNode()
     : m_SpinePath(0)
     , m_SpineScene(0)
     , m_SkeletonInstance(0)
     , m_AnimationStateInstance(0)
-    , m_AnimationInstance(0)
-    , m_AnimationId(0)
     , m_SkinId(0)
     , m_Id(0)
-    , m_Callback(0)
-    , m_NextCallback(0)
-    , m_Playing(0)
-    , m_UseCursor(0)
     , m_FindBones(0)
-    , m_HasNextCallback(0)
+    , m_FirstUpdate(1)
     {}
 };
 
@@ -140,41 +127,69 @@ static inline bool IsPingPong(dmGui::Playback playback)
 //     lua_pop(L, 1);
 // }
 
-static void SendDDF(InternalGuiNode* node, const dmDDF::Descriptor* descriptor, const char* data)
+
+static GuiSpineAnimationTrack* GetTrackFromIndex(InternalGuiNode* node, int track_index)
 {
-    if (!dmScript::IsCallbackValid(node->m_Callback))
-        return;
-
-    lua_State* L = dmScript::GetCallbackLuaContext(node->m_Callback);
-    DM_LUA_STACK_CHECK(L, 0);
-
-    if (!dmScript::SetupCallback(node->m_Callback))
-    {
-        dmLogError("Failed to setup callback");
-        return;
-    }
-
-    dmGui::LuaPushNode(L, node->m_GuiScene, node->m_GuiNode);
-    dmScript::PushHash(L, descriptor->m_NameHash);
-    dmScript::PushDDF(L, descriptor, data, true); // from comp_script.cpp
-
-    dmScript::PCall(L, 4, 0); // instance + 3
-
-    dmScript::TeardownCallback(node->m_Callback);
+    if (track_index < 0 || track_index >= node->m_AnimationTracks.Size())
+        return nullptr;
+    return &node->m_AnimationTracks[track_index];
 }
+
+static void ClearTrackCallback(GuiSpineAnimationTrack* track)
+{
+    if (track->m_CallbackInfo)
+    {
+        dmScript::DestroyCallback(track->m_CallbackInfo);
+        track->m_CallbackInfo = 0x0;
+    }
+}
+
 
 static void SendAnimationDone(InternalGuiNode* node, const spAnimationState* state, const spTrackEntry* entry, const spEvent* event)
 {
+    GuiSpineAnimationTrack* track = GetTrackFromIndex(node, entry->trackIndex);
+    if (!track)
+        return;
+
     dmGameSystemDDF::SpineAnimationDone message;
     message.m_AnimationId = dmHashString64(entry->animation->name);
-    message.m_Playback    = node->m_Playback;
-    message.m_Track       = entry->trackIndex;
+    message.m_Playback    = track->m_Playback;
+    message.m_Track       = entry->trackIndex + 1; // Convert to 1-based indexing for API
 
-    SendDDF(node, dmGameSystemDDF::SpineAnimationDone::m_DDFDescriptor, (const char*)&message);
+    // Send to track-specific callback if available
+    if (track->m_CallbackInfo && dmScript::IsCallbackValid(track->m_CallbackInfo))
+    {
+        // Store callback ID to check if callback is still valid after execution
+        uint32_t callbackId = track->m_CallbackId;
+        
+        lua_State* L = dmScript::GetCallbackLuaContext(track->m_CallbackInfo);
+        DM_LUA_STACK_CHECK(L, 0);
+
+        if (dmScript::SetupCallback(track->m_CallbackInfo))
+        {
+            dmGui::LuaPushNode(L, node->m_GuiScene, node->m_GuiNode);
+            dmScript::PushHash(L, dmGameSystemDDF::SpineAnimationDone::m_DDFDescriptor->m_NameHash);
+            dmScript::PushDDF(L, dmGameSystemDDF::SpineAnimationDone::m_DDFDescriptor, (const char*)&message, true);
+
+            dmScript::PCall(L, 4, 0); // instance + 3
+            dmScript::TeardownCallback(track->m_CallbackInfo);
+        }
+        
+        // Only clear callback if it hasn't been replaced during callback execution
+        // (user might have called gui.play_spine_anim from within the callback)
+        if (callbackId == track->m_CallbackId)
+        {
+            ClearTrackCallback(track);
+        }
+    }
 }
 
 static void SendSpineEvent(InternalGuiNode* node, const spAnimationState* state, const spTrackEntry* entry, const spEvent* event)
 {
+    GuiSpineAnimationTrack* track = GetTrackFromIndex(node, entry->trackIndex);
+    if (!track)
+        return;
+
     dmGameSystemDDF::SpineEvent message;
     message.m_AnimationId = dmHashString64(entry->animation->name);
     message.m_EventId     = dmHashString64(event->data->name);
@@ -185,13 +200,33 @@ static void SendSpineEvent(InternalGuiNode* node, const spAnimationState* state,
     message.m_String      = dmHashString64(event->stringValue?event->stringValue:"");
     message.m_Node.m_Ref  = 0;
     message.m_Node.m_ContextTableRef = 0;
+    message.m_Track       = entry->trackIndex + 1; // Convert to 1-based indexing for API
 
-    SendDDF(node, dmGameSystemDDF::SpineEvent::m_DDFDescriptor, (const char*)&message);
+    // Send to track-specific callback if available
+    if (track->m_CallbackInfo && dmScript::IsCallbackValid(track->m_CallbackInfo))
+    {
+        lua_State* L = dmScript::GetCallbackLuaContext(track->m_CallbackInfo);
+        DM_LUA_STACK_CHECK(L, 0);
+
+        if (dmScript::SetupCallback(track->m_CallbackInfo))
+        {
+            dmGui::LuaPushNode(L, node->m_GuiScene, node->m_GuiNode);
+            dmScript::PushHash(L, dmGameSystemDDF::SpineEvent::m_DDFDescriptor->m_NameHash);
+            dmScript::PushDDF(L, dmGameSystemDDF::SpineEvent::m_DDFDescriptor, (const char*)&message, true);
+
+            dmScript::PCall(L, 4, 0); // instance + 3
+            dmScript::TeardownCallback(track->m_CallbackInfo);
+        }
+        
+        // Note: For spine events, we don't clear the callback since events can occur multiple times
+        // during an animation. The callback will be cleared when the animation completes or is cancelled.
+    }
 }
 
 static void SpineEventListener(spAnimationState* state, spEventType type, spTrackEntry* entry, spEvent* event)
 {
     InternalGuiNode* node = (InternalGuiNode*)state->userData;
+    GuiSpineAnimationTrack* track = GetTrackFromIndex(node, entry->trackIndex);
 
     switch (type)
     {
@@ -206,33 +241,36 @@ static void SpineEventListener(spAnimationState* state, spEventType type, spTrac
     //     break;
     case SP_ANIMATION_COMPLETE:
         {
+            if (!track)
+                break;
+
             //printf("Animation %s complete on track %i\n", entry->animation->name, entry->trackIndex);
-    // TODO: Should we send event for looping animations as well?
+            // TODO: Should we send event for looping animations as well?
 
-            if (!IsLooping(node->m_Playback))
+            if (!IsLooping(track->m_Playback))
             {
-                node->m_Playing = 0;
-
-                if (node->m_Callback)
-                {
-                    // We only send the event if it's not looping (same behavior as before)
-                    SendAnimationDone(node, state, entry, event);
-
-                    // The animation has ended, so we won't send any more on this callback
-                    dmScript::DestroyCallback(node->m_Callback);
-                    node->m_Callback = 0;
-                }
+                // Only send the animation done event if it's not looping
+                // Note: SendAnimationDone will safely clear the callback with ID check
+                SendAnimationDone(node, state, entry, event);
             }
 
-            if (IsPingPong(node->m_Playback))
+            if (IsPingPong(track->m_Playback))
             {
-                node->m_AnimationInstance->reverse = !node->m_AnimationInstance->reverse;
+                entry->reverse = !entry->reverse;
+            }
+            
+        }
+        break;
+    case SP_ANIMATION_DISPOSE:
+        {
+            if (track && track->m_AnimationInstance == entry)
+            {
+                ClearTrackCallback(track);
+                track->m_AnimationInstance = nullptr;
+                track->m_AnimationId = 0;
             }
         }
         break;
-    // case SP_ANIMATION_DISPOSE:
-    //     printf("Track entry for animation %s disposed on track %i\n", entry->animation->name, entry->trackIndex);
-    //     break;
     case SP_ANIMATION_EVENT:
         SendSpineEvent(node, state, entry, event);
         break;
@@ -271,24 +309,43 @@ static bool PlayAnimation(InternalGuiNode* node, dmhash_t animation_id, dmGui::P
 
     spAnimation* animation = spine_scene->m_Skeleton->animations[index];
 
-    node->m_AnimationId = animation_id;
-    node->m_AnimationInstance = spAnimationState_setAnimation(node->m_AnimationStateInstance, trackIndex, animation, loop);
-
-    node->m_Playing = 1;
-    node->m_Playback = playback;
-    node->m_UseCursor = 0;
-    node->m_AnimationInstance->timeScale = playback_rate;
-    node->m_AnimationInstance->reverse = IsReverse(playback);
-    node->m_AnimationInstance->mixDuration = blend_duration;
-    node->m_AnimationInstance->trackTime = dmMath::Clamp(offset, node->m_AnimationInstance->animationStart, node->m_AnimationInstance->animationEnd);
-
-    if (node->m_NextCallback)
+    // Ensure we have enough tracks
+    if (trackIndex >= node->m_AnimationTracks.Capacity())
     {
-        // We cannot delete the current callback since we might be inside the current callback
-        dmScript::DestroyCallback(node->m_NextCallback);
+        node->m_AnimationTracks.SetCapacity(trackIndex + 4);
     }
-    node->m_HasNextCallback = 1;
-    node->m_NextCallback = callback; // Might be 0
+
+    while (trackIndex >= node->m_AnimationTracks.Size())
+    {
+        GuiSpineAnimationTrack track;
+        track.m_AnimationInstance = nullptr;
+        track.m_AnimationId = 0;
+        track.m_Playback = dmGui::PLAYBACK_LOOP_FORWARD;
+        track.m_CallbackInfo = nullptr;
+        track.m_CallbackId = 0;
+        node->m_AnimationTracks.Push(track);
+    }
+
+    GuiSpineAnimationTrack& targetTrack = node->m_AnimationTracks[trackIndex];
+
+    // Clear any existing callback for this track
+    ClearTrackCallback(&targetTrack);
+
+    // Set up the track
+    targetTrack.m_AnimationId = animation_id;
+    targetTrack.m_AnimationInstance = spAnimationState_setAnimation(node->m_AnimationStateInstance, trackIndex, animation, loop);
+    targetTrack.m_Playback = playback;
+    targetTrack.m_CallbackInfo = callback;
+    targetTrack.m_CallbackId++;
+
+    // Configure animation properties
+    targetTrack.m_AnimationInstance->timeScale = playback_rate;
+    targetTrack.m_AnimationInstance->reverse = IsReverse(playback);
+    targetTrack.m_AnimationInstance->mixDuration = blend_duration;
+    targetTrack.m_AnimationInstance->trackTime = dmMath::Clamp(offset, 
+        targetTrack.m_AnimationInstance->animationStart, 
+        targetTrack.m_AnimationInstance->animationEnd);
+
 
     return true;
 }
@@ -323,12 +380,12 @@ bool SetScene(dmGui::HScene scene, dmGui::HNode hnode, dmhash_t spine_scene)
         spSkeleton_dispose(node->m_SkeletonInstance);
     node->m_SkeletonInstance = 0;
 
-    // if we want to play an animation, the user needs to explicitly do it with gui.play_spine_anim()
-    // which will then ofc also use a callback
-    // It in turn means that we have no use for the current callback
-    // Also, we cannot delete it here, as we might be inside the current callback
-    node->m_HasNextCallback = 1;
-    node->m_NextCallback = 0;
+    // Clean up all track callbacks since we're changing scenes
+    for (int32_t i = 0; i < node->m_AnimationTracks.Size(); i++)
+    {
+        ClearTrackCallback(&node->m_AnimationTracks[i]);
+    }
+    node->m_AnimationTracks.SetSize(0);
 
     return SetupNode(spine_scene, resource, node, true);
 }
@@ -369,20 +426,38 @@ bool PlayAnimation(dmGui::HScene scene, dmGui::HNode hnode, dmhash_t animation_i
     return PlayAnimation(node, animation_id, playback, blend_duration, offset, playback_rate, track, callback);
 }
 
+static void CancelTrackAnimation(InternalGuiNode* node, int32_t track_index)
+{
+    GuiSpineAnimationTrack* track = GetTrackFromIndex(node, track_index);
+    if (!track || !track->m_AnimationInstance)
+        return;
+
+    spAnimationState_clearTrack(node->m_AnimationStateInstance, track->m_AnimationInstance->trackIndex);
+
+    ClearTrackCallback(track);
+    track->m_AnimationInstance = nullptr;
+    track->m_AnimationId = 0;
+}
+
+static void CancelAllAnimations(InternalGuiNode* node)
+{
+    for (int32_t i = 0; i < node->m_AnimationTracks.Size(); i++) {
+        CancelTrackAnimation(node, i);
+    }
+}
+
 void CancelAnimation(dmGui::HScene scene, dmGui::HNode hnode)
 {
     InternalGuiNode* node = (InternalGuiNode*)dmGui::GetNodeCustomData(scene, hnode);
-    node->m_Playing = 0;
+    CancelAllAnimations(node);
 }
 
 void CancelAnimation(dmGui::HScene scene, dmGui::HNode hnode, int32_t track)
 {
     InternalGuiNode* node = (InternalGuiNode*)dmGui::GetNodeCustomData(scene, hnode);
-    if (node->m_AnimationStateInstance)
-    {
-        int trackIndex = track - 1; // Convert from 1-based to 0-based indexing
-        spAnimationState_setEmptyAnimation(node->m_AnimationStateInstance, trackIndex, 0.0f);
-    }
+    
+    int trackIndex = track - 1; // Convert from 1-based to 0-based indexing
+    CancelTrackAnimation(node, trackIndex);
 }
 
 bool AddSkin(dmGui::HScene scene, dmGui::HNode hnode, dmhash_t skin_id_a, dmhash_t skin_id_b){
@@ -493,34 +568,47 @@ dmhash_t GetSkin(dmGui::HScene scene, dmGui::HNode hnode)
     return node->m_SkinId;
 }
 
-dmhash_t GetAnimation(dmGui::HScene scene, dmGui::HNode hnode)
+dmhash_t GetAnimation(dmGui::HScene scene, dmGui::HNode hnode, int32_t track)
 {
     InternalGuiNode* node = (InternalGuiNode*)dmGui::GetNodeCustomData(scene, hnode);
-    return node->m_AnimationId;
+    
+    int trackIndex = track - 1;
+    GuiSpineAnimationTrack* targetTrack = GetTrackFromIndex(node, trackIndex);
+    return targetTrack ? targetTrack->m_AnimationId : 0;
 }
 
-bool SetCursor(dmGui::HScene scene, dmGui::HNode hnode, float cursor)
+bool SetCursor(dmGui::HScene scene, dmGui::HNode hnode, float cursor, int32_t track)
 {
     InternalGuiNode* node = (InternalGuiNode*)dmGui::GetNodeCustomData(scene, hnode);
-    if (!node->m_AnimationInstance)
+    
+    int trackIndex = track - 1;
+    GuiSpineAnimationTrack* targetTrack = GetTrackFromIndex(node, trackIndex);
+    if (!targetTrack || !targetTrack->m_AnimationInstance)
     {
         return false;
     }
 
     float unit_0_1 = fmodf(cursor + 1.0f, 1.0f);
 
-    float duration = node->m_AnimationInstance->animationEnd - node->m_AnimationInstance->animationStart;
+    float duration = targetTrack->m_AnimationInstance->animationEnd - targetTrack->m_AnimationInstance->animationStart;
     float t = unit_0_1 * duration;
 
-    node->m_AnimationInstance->trackTime = t;
-    node->m_UseCursor = 1;
+    targetTrack->m_AnimationInstance->trackTime = t;
     return true;
 }
 
-float GetCursor(dmGui::HScene scene, dmGui::HNode hnode)
+float GetCursor(dmGui::HScene scene, dmGui::HNode hnode, int32_t track)
 {
     InternalGuiNode* node = (InternalGuiNode*)dmGui::GetNodeCustomData(scene, hnode);
-    spTrackEntry* entry = node->m_AnimationInstance;
+    
+    int trackIndex = track - 1;
+    GuiSpineAnimationTrack* targetTrack = GetTrackFromIndex(node, trackIndex);
+    if (!targetTrack || !targetTrack->m_AnimationInstance)
+    {
+        return 0.0f;
+    }
+    
+    spTrackEntry* entry = targetTrack->m_AnimationInstance;
     float unit = 0.0f;
     if (entry)
     {
@@ -533,21 +621,29 @@ float GetCursor(dmGui::HScene scene, dmGui::HNode hnode)
     return unit;
 }
 
-bool SetPlaybackRate(dmGui::HScene scene, dmGui::HNode hnode, float playback_rate)
+bool SetPlaybackRate(dmGui::HScene scene, dmGui::HNode hnode, float playback_rate, int32_t track)
 {
     InternalGuiNode* node = (InternalGuiNode*)dmGui::GetNodeCustomData(scene, hnode);
-    if (!node->m_AnimationInstance)
+    
+    int trackIndex = track - 1;
+    GuiSpineAnimationTrack* targetTrack = GetTrackFromIndex(node, trackIndex);
+    if (!targetTrack || !targetTrack->m_AnimationInstance)
         return false;
-    node->m_AnimationInstance->timeScale = playback_rate;
+    
+    targetTrack->m_AnimationInstance->timeScale = playback_rate;
     return true;
 }
 
-float GetPlaybackRate(dmGui::HScene scene, dmGui::HNode hnode)
+float GetPlaybackRate(dmGui::HScene scene, dmGui::HNode hnode, int32_t track)
 {
     InternalGuiNode* node = (InternalGuiNode*)dmGui::GetNodeCustomData(scene, hnode);
-    if (!node->m_AnimationInstance)
+    
+    int trackIndex = track - 1;
+    GuiSpineAnimationTrack* targetTrack = GetTrackFromIndex(node, trackIndex);
+    if (!targetTrack || !targetTrack->m_AnimationInstance)
         return 1.0f;
-    return node->m_AnimationInstance->timeScale;
+    
+    return targetTrack->m_AnimationInstance->timeScale;
 }
 
 bool SetAttachment(dmGui::HScene scene, dmGui::HNode hnode, dmhash_t slot_id, dmhash_t attachment_id)
@@ -770,6 +866,13 @@ static void DestroyNode(InternalGuiNode* node)
 {
     DeleteBones(node);
 
+    // Clean up all track callbacks
+    for (int32_t i = 0; i < node->m_AnimationTracks.Size(); i++)
+    {
+        ClearTrackCallback(&node->m_AnimationTracks[i]);
+    }
+    node->m_AnimationTracks.SetCapacity(0);
+
     if (node->m_AnimationStateInstance)
         spAnimationState_dispose(node->m_AnimationStateInstance);
     if (node->m_SkeletonInstance)
@@ -791,15 +894,13 @@ static void GuiDestroy(const dmGameSystem::CompGuiNodeContext* ctx, const dmGame
 {
     InternalGuiNode* node = (InternalGuiNode*)nodectx->m_NodeData;
 
-    // Always beware of deleting a callback to make sure it isn't done within the actual callback
-    if (node->m_Callback)
+    // Clean up all track callbacks
+    for (int32_t i = 0; i < node->m_AnimationTracks.Size(); i++)
     {
-        dmScript::DestroyCallback(node->m_Callback);
+        ClearTrackCallback(&node->m_AnimationTracks[i]);
     }
-    if (node->m_NextCallback)
-    {
-        dmScript::DestroyCallback(node->m_NextCallback);
-    }
+
+    // Track callbacks are already cleaned up above
 
     delete node;
 }
@@ -830,6 +931,9 @@ static bool SetupNode(dmhash_t path, SpineSceneResource* resource, InternalGuiNo
     node->m_AnimationStateInstance->userData = node;
     node->m_AnimationStateInstance->listener = SpineEventListener;
 
+    // Initialize animation tracks array
+    node->m_AnimationTracks.SetCapacity(8); // Start with capacity for 8 tracks
+
     spSkeleton_setToSetupPose(node->m_SkeletonInstance);
     spSkeleton_updateWorldTransform(node->m_SkeletonInstance, SP_PHYSICS_NONE);
 
@@ -857,7 +961,6 @@ static void* GuiClone(const dmGameSystem::CompGuiNodeContext* ctx, const dmGameS
     // We don't get a GuiSetNodeDesc call when cloning, as we should already have the data we need in the node itself
     dst->m_Id = src->m_Id;
     dst->m_AdjustMode = src->m_AdjustMode;
-    dst->m_AnimationId = src->m_AnimationId;
     dst->m_SkinId = src->m_SkinId;
 
     // Setup the spine structures
@@ -881,42 +984,51 @@ static void* GuiClone(const dmGameSystem::CompGuiNodeContext* ctx, const dmGameS
     memcpy(dst->m_BonesNames.Begin(), src->m_BonesNames.Begin(), sizeof(dmhash_t) * num_bones);
 
 
-    // Now set the correct animation
+    // Copy transform
     dst->m_Transform    = src->m_Transform;
-    dst->m_Playback     = src->m_Playback;
-    dst->m_Playing      = src->m_Playing;
-    dst->m_UseCursor    = src->m_UseCursor;
 
-    if (dst->m_AnimationId)
+    // Copy all tracks from source
+    uint32_t num_tracks = src->m_AnimationTracks.Size();
+    if (num_tracks > 0)
     {
-        uint32_t index = FindAnimationIndex(dst, dst->m_AnimationId);
-        if (index == INVALID_ANIMATION_INDEX)
-        {
-            dmLogError("No animation '%s' found", dmHashReverseSafe64(dst->m_AnimationId));
-        }
-        else if (index >= dst->m_SpineScene->m_Skeleton->animationsCount)
-        {
-            dmLogError("Animation index %u is too large. Number of animations are %u", index, dst->m_SpineScene->m_Skeleton->animationsCount);
-            index = INVALID_ANIMATION_INDEX;
-        }
+        dst->m_AnimationTracks.SetCapacity(num_tracks);
+        dst->m_AnimationTracks.SetSize(num_tracks);
 
-        if (index != INVALID_ANIMATION_INDEX)
+        for (uint32_t i = 0; i < num_tracks; i++)
         {
-            spAnimation* animation = dst->m_SpineScene->m_Skeleton->animations[index];
-            if (animation)
+            const GuiSpineAnimationTrack& srcTrack = src->m_AnimationTracks[i];
+            GuiSpineAnimationTrack& dstTrack = dst->m_AnimationTracks[i];
+
+            dstTrack.m_AnimationId = srcTrack.m_AnimationId;
+            dstTrack.m_Playback = srcTrack.m_Playback;
+            dstTrack.m_CallbackInfo = nullptr; // Don't copy callbacks
+            dstTrack.m_CallbackId = 0;
+            dstTrack.m_AnimationInstance = nullptr;
+
+            if (srcTrack.m_AnimationId && srcTrack.m_AnimationInstance)
             {
-                int trackIndex = 0;
-                int loop = IsLooping(dst->m_Playback);
-                dst->m_AnimationId = src->m_AnimationId;
-                dst->m_AnimationInstance = spAnimationState_setAnimation(dst->m_AnimationStateInstance, trackIndex, animation, loop);
+                uint32_t index = FindAnimationIndex(dst, srcTrack.m_AnimationId);
+                if (index != INVALID_ANIMATION_INDEX && index < dst->m_SpineScene->m_Skeleton->animationsCount)
+                {
+                    spAnimation* animation = dst->m_SpineScene->m_Skeleton->animations[index];
+                    if (animation)
+                    {
+                        int loop = IsLooping(srcTrack.m_Playback);
+                        dstTrack.m_AnimationInstance = spAnimationState_setAnimation(dst->m_AnimationStateInstance, i, animation, loop);
 
-                // Now copy the state of the animation
-                dst->m_AnimationInstance->trackTime = src->m_AnimationInstance->trackTime;
-                dst->m_AnimationInstance->reverse = src->m_AnimationInstance->reverse;
-                dst->m_AnimationInstance->timeScale = src->m_AnimationInstance->timeScale;
+                        // Copy the state of the animation
+                        if (dstTrack.m_AnimationInstance)
+                        {
+                            dstTrack.m_AnimationInstance->trackTime = srcTrack.m_AnimationInstance->trackTime;
+                            dstTrack.m_AnimationInstance->reverse = srcTrack.m_AnimationInstance->reverse;
+                            dstTrack.m_AnimationInstance->timeScale = srcTrack.m_AnimationInstance->timeScale;
+                        }
+                    }
+                }
             }
         }
     }
+
 
     return dst;
 }
@@ -934,7 +1046,7 @@ static void GuiSetNodeDesc(const dmGameSystem::CompGuiNodeContext* ctx, const dm
 
     node->m_Id = node_desc->m_Id;
     node->m_AdjustMode = (dmGui::AdjustMode)node_desc->m_AdjustMode;
-    node->m_AnimationId = dmHashString64(node_desc->m_SpineDefaultAnimation); // TODO: Q: Is the default playmode specified anywhere?
+    dmhash_t default_animation_id = dmHashString64(node_desc->m_SpineDefaultAnimation); // TODO: Q: Is the default playmode specified anywhere?
     node->m_SkinId = dmHashString64(node_desc->m_SpineSkin);
 
     SetupNode(name_hash, resource, node, true);
@@ -943,8 +1055,8 @@ static void GuiSetNodeDesc(const dmGameSystem::CompGuiNodeContext* ctx, const dm
         SetSkin(node->m_GuiScene, node->m_GuiNode, node->m_SkinId);
     }
 
-    if (node->m_AnimationId) {
-        PlayAnimation(node, node->m_AnimationId, dmGui::PLAYBACK_LOOP_FORWARD, 0.0f, 0.0f, 1.0f, 1, 0);
+    if (default_animation_id) {
+        PlayAnimation(node, default_animation_id, dmGui::PLAYBACK_LOOP_FORWARD, 0.0f, 0.0f, 1.0f, 1, 0);
     }
 }
 
@@ -1024,20 +1136,20 @@ static void GuiUpdate(const dmGameSystem::CustomNodeCtx* nodectx, float dt)
 
     if (!node->m_AnimationStateInstance)
         return;
+    float anim_dt = dt;
 
-    if (node->m_HasNextCallback)
+    // Check if any track is playing
+    bool anyTrackPlaying = false;
+    for (int32_t i = 0; i < node->m_AnimationTracks.Size(); i++)
     {
-        if (node->m_Callback)
-            dmScript::DestroyCallback(node->m_Callback);
-        node->m_Callback = node->m_NextCallback;
-        node->m_HasNextCallback = 0;
-        node->m_NextCallback = 0;
+        if (node->m_AnimationTracks[i].m_AnimationInstance)
+        {
+            anyTrackPlaying = true;
+            break;
+        }
     }
 
-    float anim_dt = node->m_UseCursor ? 0.0f : dt;
-    node->m_UseCursor = 0;
-
-    if (node->m_Playing)
+    if (anyTrackPlaying)
     {
         spAnimationState_update(node->m_AnimationStateInstance, anim_dt);
         spAnimationState_apply(node->m_AnimationStateInstance, node->m_SkeletonInstance);

--- a/defold-spine/src/gui_node_spine.h
+++ b/defold-spine/src/gui_node_spine.h
@@ -7,9 +7,11 @@
 #include <dmsdk/gui/gui.h>
 #include <dmsdk/script/script.h>
 #include <dmsdk/dlib/vmath.h>
+#include <dmsdk/dlib/array.h>
 
 // Forward declarations for Spine types (global namespace, not dmSpine)
 struct spIkConstraint;
+struct spTrackEntry;
 
 namespace dmSpine
 {
@@ -21,6 +23,16 @@ struct GuiIKTarget
     spIkConstraint*                         m_Constraint;
     dmGui::HNode                            m_TargetNode;     // for following a GUI node
     dmVMath::Point3                         m_Position;       // for fixed position
+};
+
+// Animation track structure for GUI spine nodes
+struct GuiSpineAnimationTrack 
+{
+    spTrackEntry*                           m_AnimationInstance;
+    dmhash_t                                m_AnimationId;
+    dmGui::Playback                         m_Playback;
+    dmScript::LuaCallbackInfo*              m_CallbackInfo;
+    uint32_t                                m_CallbackId;
 };
 
 bool        SetScene(dmGui::HScene scene, dmGui::HNode hnode, dmhash_t spine_scene);
@@ -36,13 +48,13 @@ bool        ClearSkin(dmGui::HScene scene, dmGui::HNode hnode, dmhash_t spine_sk
 bool        CopySkin(dmGui::HScene scene, dmGui::HNode hnode, dmhash_t spine_skin_id_a, dmhash_t spine_skine_id_b);
 bool        SetSkin(dmGui::HScene scene, dmGui::HNode hnode, dmhash_t spine_skin_id);
 dmhash_t    GetSkin(dmGui::HScene scene, dmGui::HNode hnode);
-dmhash_t    GetAnimation(dmGui::HScene scene, dmGui::HNode hnode);
+dmhash_t    GetAnimation(dmGui::HScene scene, dmGui::HNode hnode, int32_t track);
 
-bool        SetCursor(dmGui::HScene scene, dmGui::HNode hnode, float cursor);
-float       GetCursor(dmGui::HScene scene, dmGui::HNode hnode);
+bool        SetCursor(dmGui::HScene scene, dmGui::HNode hnode, float cursor, int32_t track);
+float       GetCursor(dmGui::HScene scene, dmGui::HNode hnode, int32_t track);
 
-bool        SetPlaybackRate(dmGui::HScene scene, dmGui::HNode hnode, float playback_rate);
-float       GetPlaybackRate(dmGui::HScene scene, dmGui::HNode hnode);
+bool        SetPlaybackRate(dmGui::HScene scene, dmGui::HNode hnode, float playback_rate, int32_t track);
+float       GetPlaybackRate(dmGui::HScene scene, dmGui::HNode hnode, int32_t track);
 
 dmGui::HNode GetBone(dmGui::HScene scene, dmGui::HNode hnode, dmhash_t bone_id);
 

--- a/examples/basic_animation/basic_animation.script
+++ b/examples/basic_animation/basic_animation.script
@@ -93,6 +93,26 @@ function on_input(self, action_id, action)
 			self.ik_mode = "follow"
 			print("GO IK mode: follow mouse")
 		end
+	elseif action_id == hash("key_c") and action.pressed then
+		-- Test cursor control on different tracks
+		print("GO: Testing cursor control")
+		go.set(self.url, "cursor", 0.5)  -- Set track 1 cursor to 50% (old API)
+		print("GO: Set track 1 cursor to 0.5 using go.set")
+		
+		-- Note: Spine GO component uses go.set/go.get for properties, not spine.set_cursor
+		-- This is different from GUI which has gui.set_spine_cursor functions
+		local cursor = go.get(self.url, "cursor")
+		print("GO: Current cursor value:", cursor)
+	elseif action_id == hash("key_p") and action.pressed then
+		-- Test playback rate control on different tracks
+		print("GO: Testing playback rate control")
+		go.set(self.url, "playback_rate", 2.0)  -- Set track 1 to double speed (old API)
+		print("GO: Set track 1 playback rate to 2.0 using go.set")
+		
+		-- Note: Spine GO component uses go.set/go.get for properties, not spine.set_playback_rate
+		-- This is different from GUI which has gui.set_spine_playback_rate functions
+		local rate = go.get(self.url, "playback_rate")
+		print("GO: Current playback rate:", rate)
 	end
 end
 

--- a/examples/basic_animation/basic_animation.script
+++ b/examples/basic_animation/basic_animation.script
@@ -4,11 +4,16 @@ end
 
 local function play_animation(self)
 	spine.play_anim(self.url, "run", go.PLAYBACK_ONCE_FORWARD, {}, 
-		function(self, message_id, message, sender)
-			assert(type(message_id) ~= "string")
-			pprint("GO callback", message_id, message, sender)
+	function(self, message_id, message, sender)
 			if (message_id == hash("spine_animation_done")) then
-				spine.play_anim(self.url, "run", go.PLAYBACK_LOOP_FORWARD, {}, callback)
+				spine.play_anim(self.url, "run", go.PLAYBACK_ONCE_FORWARD, {}, 
+					function(self, message_id, message, sender)
+						assert(type(message_id) ~= "string")
+						pprint("GO callback", message_id, message, sender)
+						if (message_id == hash("spine_animation_done")) then
+							spine.play_anim(self.url, "run", go.PLAYBACK_LOOP_FORWARD, {}, callback)
+						end
+					end)
 			end
 		end)
 	self.is_playing = true
@@ -43,6 +48,7 @@ function init(self)
 	spine.play_anim(self.url, "idle", go.PLAYBACK_LOOP_FORWARD, { track = 1 })
 	spine.play_anim(self.url, "aim", go.PLAYBACK_LOOP_FORWARD, { track = 2 })
 	spine.set_ik_target(self.url, "aim-ik", "ik-target")
+	self.ik_mode = "follow" -- track current IK mode
 end
 
 function final(self)
@@ -61,7 +67,11 @@ end
 
 function on_input(self, action_id, action)
 	if action_id == nil then
-		go.set("ik-target", "position", vmath.vector3(action.x, action.y, 0))
+		self.mouse_pos = vmath.vector3(action.x, action.y, 0)
+		-- Move the IK target only in follow mode
+		if self.ik_mode == "follow" then
+			go.set("ik-target", "position", self.mouse_pos)
+		end
 	elseif action_id == hash("mouse_button_right") and action.pressed then
 		if self.is_playing then
 			spine.cancel(self.url, { track = 1 })
@@ -71,6 +81,18 @@ function on_input(self, action_id, action)
 		end
 	elseif action_id == hash("mouse_button_left") and action.pressed then
 		spine.play_anim(self.url, "shoot", go.PLAYBACK_ONCE_FORWARD, { track = 3 })
+	elseif action_id == hash("key_space") and action.pressed then
+		-- Toggle between fixed and follow mode
+		if self.ik_mode == "follow" then
+			-- Switch to fixed mode - set IK target to current mouse position
+			go.set("ik-target", "position", self.mouse_pos)
+			self.ik_mode = "fixed"
+			print("GO IK mode: fixed at current mouse position")
+		else
+			-- Switch back to follow mode
+			self.ik_mode = "follow"
+			print("GO IK mode: follow mouse")
+		end
 	end
 end
 

--- a/examples/basic_animation/basic_animation_gui.gui_script
+++ b/examples/basic_animation/basic_animation_gui.gui_script
@@ -1,6 +1,22 @@
 
+local function gui_callback(self, node, message_id, message)
+	pprint("GUI callback", message_id, message, node)
+end
+
 local function play_gui_animation(self)
-	gui.play_spine_anim(self.spine_node, "run", gui.PLAYBACK_LOOP_FORWARD, {})
+	gui.play_spine_anim(self.spine_node, "run", gui.PLAYBACK_ONCE_FORWARD, {},
+	function(self, node, message_id, message)
+		if (message_id == hash("spine_animation_done")) then
+			gui.play_spine_anim(self.spine_node, "run", gui.PLAYBACK_ONCE_FORWARD, {},
+				function(self, node, message_id, message)
+					assert(type(message_id) ~= "string")
+					pprint("GUI callback", message_id, message, node)
+					if (message_id == hash("spine_animation_done")) then
+						gui.play_spine_anim(self.spine_node, "run", gui.PLAYBACK_LOOP_FORWARD, {}, gui_callback)
+					end
+				end)
+		end
+	end)
 	self.is_playing = true
 end
 
@@ -80,11 +96,23 @@ function on_input(self, action_id, action)
 	elseif action_id == hash("mouse_button_left") and action.pressed then
 		gui.play_spine_anim(self.spine_node, "shoot", gui.PLAYBACK_ONCE_FORWARD, { track = 3 })
 	elseif action_id == hash("key_space") and action.pressed then
-		-- Test position-based IK (new functionality)
-		gui.set_spine_ik_target_position(self.spine_node, "aim-ik", self.mouse_pos)
-		self.ik_mode = "fixed"
-		-- Change target color to indicate fixed mode
-		gui.set_color(self.ik_target, vmath.vector4(0, 0, 1, 1)) -- blue for fixed
+		-- Toggle between fixed and follow mode
+		if self.ik_mode == "follow" then
+			-- Switch to fixed mode
+			gui.set_spine_ik_target_position(self.spine_node, "aim-ik", self.mouse_pos)
+			self.ik_mode = "fixed"
+			-- Change target color to indicate fixed mode
+			gui.set_color(self.ik_target, vmath.vector4(0, 0, 1, 1)) -- blue for fixed
+			print("IK mode: fixed at current mouse position")
+		else
+			-- Switch back to follow mode
+			gui.reset_spine_ik_target(self.spine_node, "aim-ik")
+			gui.set_spine_ik_target(self.spine_node, "aim-ik", self.ik_target)
+			self.ik_mode = "follow"
+			-- Change target color back to red for follow mode
+			gui.set_color(self.ik_target, vmath.vector4(1, 0, 0, 1)) -- red for follow
+			print("IK mode: follow mouse")
+		end
 	elseif action_id == hash("key_r") and action.pressed then
 		-- Reset IK target and return to follow mode
 		gui.reset_spine_ik_target(self.spine_node, "aim-ik")

--- a/examples/basic_animation/basic_animation_gui.gui_script
+++ b/examples/basic_animation/basic_animation_gui.gui_script
@@ -56,13 +56,6 @@ function init(self)
 	gui.set_spine_ik_target(self.spine_node, "aim-ik", self.ik_target)
 	self.ik_mode = "follow" -- track current IK mode
 	
-	print("GUI IK setup complete - move mouse to control aim")
-	print("Controls:")
-	print("  Mouse movement: IK follows red target")
-	print("  Space: Set IK to fixed position")
-	print("  R: Reset IK target")
-	print("  Left click: Shoot")
-	print("  Right click: Toggle run animation")
 end
 
 function final(self)
@@ -113,6 +106,32 @@ function on_input(self, action_id, action)
 			gui.set_color(self.ik_target, vmath.vector4(1, 0, 0, 1)) -- red for follow
 			print("IK mode: follow mouse")
 		end
+	elseif action_id == hash("key_c") and action.pressed then
+		-- Test cursor control on different tracks
+		print("GUI: Testing cursor control")
+		
+		-- Old API: Set cursor without track (defaults to track 1)
+		gui.set_spine_cursor(self.spine_node, 0.5)
+		local cursor = gui.get_spine_cursor(self.spine_node)
+		print("GUI: Set track 1 cursor to 0.5, current value:", cursor)
+		
+		-- New API: Set cursor on specific tracks
+		gui.set_spine_cursor(self.spine_node, 0.25, { track = 2 })
+		local cursor2 = gui.get_spine_cursor(self.spine_node, { track = 2 })
+		print("GUI: Set track 2 cursor to 0.25, current value:", cursor2)
+	elseif action_id == hash("key_p") and action.pressed then
+		-- Test playback rate control on different tracks
+		print("GUI: Testing playback rate control")
+		
+		-- Old API: Set playback rate without track (defaults to track 1)
+		gui.set_spine_playback_rate(self.spine_node, 2.0)
+		local rate = gui.get_spine_playback_rate(self.spine_node)
+		print("GUI: Set track 1 playback rate to 2.0, current value:", rate)
+		
+		-- New API: Set playback rate on specific tracks
+		gui.set_spine_playback_rate(self.spine_node, 0.5, { track = 2 })
+		local rate2 = gui.get_spine_playback_rate(self.spine_node, { track = 2 })
+		print("GUI: Set track 2 playback rate to 0.5, current value:", rate2)
 	elseif action_id == hash("key_r") and action.pressed then
 		-- Reset IK target and return to follow mode
 		gui.reset_spine_ik_target(self.spine_node, "aim-ik")


### PR DESCRIPTION
# ⚠️ Breaking Change: GUI Spine Callback Behavior

  Previous Behavior (Before Multi-Track):
  ```lua
  gui.play_spine_anim(node, "run", gui.PLAYBACK_ONCE_FORWARD, {},
  function(self, node)
      -- Callback was only called on animation completion
      -- No need to check message type
      print("Animation completed")
  end)
  ```

  New Behavior (Multi-Track Implementation):
  ```lua
  gui.play_spine_anim(node, "run", gui.PLAYBACK_ONCE_FORWARD, {},
  function(self, node, message_id, message)
      -- Callback now receives both completion AND spine events
      if message_id == hash("spine_animation_done") then
          print("Animation completed on track", message.track)
      elseif message_id == hash("spine_event") then
          print("Spine event:", message.event_id)
      end
  end)
  ```

# 🆕Added support tracks for GUI Spine nodes. 

## gui.play_spine_anim
  ```lua
  -- Without tracks: Single animation (uses default track 1)
  gui.play_spine_anim(node, "run", gui.PLAYBACK_ONCE_FORWARD)

  -- With tracks: Multi-track animations for layered effects
  gui.play_spine_anim(node, "idle", gui.PLAYBACK_LOOP_FORWARD, { track = 1 })  -- base animation
  gui.play_spine_anim(node, "aim", gui.PLAYBACK_LOOP_FORWARD, { track = 2 })   -- overlay animation
  gui.play_spine_anim(node, "shoot", gui.PLAYBACK_ONCE_FORWARD, { track = 3 }) -- one-shot action
```
  ## gui.cancel_spine
  ```lua
  -- Without tracks: Cancel all animations
  gui.cancel_spine(node)

  -- With tracks: Cancel specific tracks or all tracks
  gui.cancel_spine(node, { track = 2 })   -- cancel only track 2
  gui.cancel_spine(node, { track = -1 })  -- cancel all tracks (explicit)
```

##  gui.get_spine_animation

  ```lua
  -- Without tracks: Get animation from default track
  local anim_id = gui.get_spine_animation(node)

  -- With tracks: Get animation from specific track
  local track1_anim = gui.get_spine_animation(node, { track = 1 })
  local track2_anim = gui.get_spine_animation(node, { track = 2 })
```

##  gui.set_spine_cursor / gui.get_spine_cursor

  ```lua
  -- Without tracks: Control cursor on default track
  gui.set_spine_cursor(node, 0.5)
  local cursor = gui.get_spine_cursor(node)

  -- With tracks: Control cursor per track
  gui.set_spine_cursor(node, 0.5, { track = 1 })  -- set track 1 to 50%
  gui.set_spine_cursor(node, 0.8, { track = 2 })  -- set track 2 to 80%
  local cursor1 = gui.get_spine_cursor(node, { track = 1 })
  local cursor2 = gui.get_spine_cursor(node, { track = 2 })
```

##  gui.set_spine_playback_rate / gui.get_spine_playback_rate

  ```lua
  -- Without tracks: Control playback rate globally
  gui.set_spine_playback_rate(node, 2.0)
  local rate = gui.get_spine_playback_rate(node)

  -- With tracks: Independent playback rates per track
  gui.set_spine_playback_rate(node, 1.0, { track = 1 })  -- normal speed walk
  gui.set_spine_playback_rate(node, 0.5, { track = 2 })  -- slow breathing
  gui.set_spine_playback_rate(node, 3.0, { track = 3 })  -- fast shooting
```

  Complete Multi-Track Animation Example

  ```lua
  function init(self)
      local node = gui.get_node("character")

      -- Old approach: Single animation at a time
      -- gui.play_spine_anim(node, "idle", gui.PLAYBACK_LOOP_FORWARD)

      -- New approach: Layered animations
      gui.play_spine_anim(node, "idle", gui.PLAYBACK_LOOP_FORWARD, { track = 1 })     -- base movement
      gui.play_spine_anim(node, "breathe", gui.PLAYBACK_LOOP_FORWARD, { track = 2 })  -- breathing overlay

      -- Interactive one-shot animation on separate track
      gui.play_spine_anim(node, "wave", gui.PLAYBACK_ONCE_FORWARD, { track = 3 })
  end

  function on_input(self, action_id, action)
      local node = gui.get_node("character")

      if action_id == hash("shoot") then
          -- Play shooting animation without interrupting base animations
          gui.play_spine_anim(node, "shoot", gui.PLAYBACK_ONCE_FORWARD, { track = 4 })
      elseif action_id == hash("stop_breathing") then
          -- Stop only the breathing animation
          gui.cancel_spine(node, { track = 2 })
      end
  end
  ```

Fix https://github.com/defold/extension-spine/issues/200
Fix https://github.com/defold/extension-spine/issues/54