### PR TITLE
Fix crash when using blending or masks

### DIFF
--- a/defold-spine/src/comp_spine_model.cpp
+++ b/defold-spine/src/comp_spine_model.cpp
@@ -997,7 +997,12 @@ namespace dmSpine
 
                 uint32_t merged_size = scratch_draw_descs.Size();
                 uint32_t ro_count_begin = world->m_RenderObjects.Size();
-                world->m_RenderObjects.SetSize(world->m_RenderObjects.Size() + merged_size);
+                uint32_t expected_size = world->m_RenderObjects.Size() + merged_size;
+                if (world->m_RenderObjects.Capacity() < expected_size)
+                {
+                    world->m_RenderObjects.OffsetCapacity(expected_size - world->m_RenderObjects.Capacity());
+                }
+                world->m_RenderObjects.SetSize(expected_size);
 
                 for (int i = 0; i < merged_size; ++i)
                 {


### PR DESCRIPTION
We expect count of render objects is equal to count of components https://github.com/defold/extension-spine/blob/708cd0c6acbb2e7583f7f9012a1437fe9f3b5834/defold-spine/src/comp_spine_model.cpp#L111

But it's not true anymore in case masks of blend modes used. So we have to dynamicly change buffer when we know how many render objects we have

Fix https://github.com/defold/extension-spine/issues/251