### PR TITLE
add arm64-linux support

### DIFF
--- a/utils/build_libs.sh
+++ b/utils/build_libs.sh
@@ -8,7 +8,7 @@ PROJECT_LIB_DIR=${PROJECT_DIR}/lib
 
 PLATFORMS=$1
 if [ "" == "${PLATFORMS}" ]; then
-    PLATFORMS="x86_64-macos arm64-macos x86_64-linux x86_64-win32 x86-win32 arm64-ios x86_64-ios arm64-android armv7-android js-web wasm-web"
+    PLATFORMS="x86_64-macos arm64-macos x86_64-linux arm64-linux x86_64-win32 x86-win32 arm64-ios x86_64-ios arm64-android armv7-android js-web wasm-web"
 fi
 
 DEFAULT_SERVER_NAME=build.defold.com

--- a/utils/build_plugins.sh
+++ b/utils/build_plugins.sh
@@ -83,7 +83,7 @@ function build_plugin() {
 
 PLATFORMS=$1
 if [ "" == "${PLATFORM}" ]; then
-    PLATFORMS="x86_64-macos arm64-macos x86_64-linux x86_64-win32"
+    PLATFORMS="x86_64-macos arm64-macos x86_64-linux arm64-linux x86_64-win32"
 fi
 
 if [[ $# -gt 0 ]] ; then


### PR DESCRIPTION
Hello!
Sometimes there is a need to build a version directly on an ARM device for testing purposes. Bob handles this perfectly, but Spine unfortunately lacks this capability.
Unfortunately, I’m not fully sure about the correct process for building the .so files. I managed to build and test them locally, but I’m not confident enough to say that no unnecessary dependencies or artifacts ended up included there.