### PR TITLE
Fix one frame lag if parent game object change its transform over time

### DIFF
--- a/defold-spine/src/comp_spine_model.cpp
+++ b/defold-spine/src/comp_spine_model.cpp
@@ -799,7 +799,7 @@ namespace dmSpine
     }
 
 
-    dmGameObject::UpdateResult CompSpineModelUpdate(const dmGameObject::ComponentsUpdateParams& params, dmGameObject::ComponentsUpdateResult& update_result)
+    dmGameObject::UpdateResult CompSpineModelLateUpdate(const dmGameObject::ComponentsUpdateParams& params, dmGameObject::ComponentsUpdateResult& update_result)
     {
         SpineModelWorld* world = (SpineModelWorld*)params.m_World;
 
@@ -1569,7 +1569,7 @@ namespace dmSpine
             // ComponentTypeSetInitFn(type, CompSpineModelInit);
             // ComponentTypeSetFinalFn(type, CompSpineModelFinal);
         ComponentTypeSetAddToUpdateFn(type, CompSpineModelAddToUpdate);
-        ComponentTypeSetUpdateFn(type, CompSpineModelUpdate);
+        ComponentTypeSetLateUpdateFn(type, CompSpineModelLateUpdate);
         ComponentTypeSetPostUpdateFn(type, CompSpineModelPostUpdate);
         ComponentTypeSetRenderFn(type, CompSpineModelRender);
         ComponentTypeSetOnMessageFn(type, CompSpineModelOnMessage);


### PR DESCRIPTION
Update transform moved to LateUpdate. Now spine transforms calculated after parents game object transform at the same frame.

Fixes #290 
Fixes #156 
Fixes #94 